### PR TITLE
README.mdにAWSアイコンを使ったMermaid構成図を追加

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,68 @@
+# language of the project (csharp, python, rust, java, typescript, go, cpp, or ruby)
+#  * For C, use cpp
+#  * For JavaScript, use typescript
+# Special requirements:
+#  * csharp: Requires the presence of a .sln file in the project folder.
+language: typescript
+
+# whether to use the project's gitignore file to ignore files
+# Added on 2025-04-07
+ignore_all_files_in_gitignore: true
+# list of additional paths to ignore
+# same syntax as gitignore, so you can use * and **
+# Was previously called `ignored_dirs`, please update your config if you are using that.
+# Added (renamed) on 2025-04-07
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+
+# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project by name.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_lines`: Deletes a range of lines within a file.
+#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
+#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
+#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Gets the initial instructions for the current project.
+#     Should only be used in settings where the system prompt cannot be set,
+#     e.g. in clients you have no control over, like Claude Desktop.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_at_line`: Inserts content at a given line in a file.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: Lists memories in Serena's project-specific memory store.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
+#  * `remove_project`: Removes a project from the Serena configuration.
+#  * `replace_lines`: Replaces a range of lines within a file with new content.
+#  * `replace_symbol_body`: Replaces the full definition of a symbol.
+#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
+#  * `switch_modes`: Activates modes by providing a list of their names
+#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
+#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
+#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
+#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+excluded_tools: []
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+project_name: "cloudfront-cdn-template"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,49 @@
 # cloudfront-cdn-template
 
+## Architecture
+
+```mermaid
+graph LR
+    User[👤<br/>User] --> CF[☁️<br/>Amazon CloudFront]
+    
+    CF --> CFFunc[⚡<br/>CloudFront Functions<br/>Viewer Request]
+    CF --> S3[🪣<br/>Amazon S3<br/>Origin Bucket]
+    
+    CF -.-> OAC[🔐<br/>Origin Access Control<br/>OAC]
+    OAC --> S3
+    
+    S3 -.-> KMS[🔑<br/>AWS KMS<br/>Customer Managed Key<br/><i>Optional</i>]
+    
+    subgraph AWS["AWS Cloud"]
+        CF
+        CFFunc
+        S3
+        OAC
+        KMS
+    end
+    
+    classDef aws fill:#fff,color:#345,stroke:#345,stroke-width:2px
+    classDef user fill:#4CAF50,stroke:#2E7D32,stroke-width:2px,color:#fff
+    classDef optional fill:#FFC107,stroke:#F57C00,stroke-width:2px,color:#000
+    classDef awsRegion fill:#fff,color:#345,stroke:#345,stroke-width:2px
+    
+    class CF,CFFunc,S3,OAC aws
+    class User user
+    class KMS optional
+    class AWS awsRegion
+```
+
+## Features
+
+- **CloudFront CDN**: エッジキャッシュによるグローバルなコンテンツ配信
+- **S3静的ホスティング**: Origin Access Controlによるセキュアなプライベートバケット
+- **CloudFront Function**: SPAルーティング用の自動index.html転送機能
+- **KMS暗号化**: S3オブジェクトのオプションサーバーサイド暗号化
+- **セキュリティ**: CloudFrontからのみアクセス可能なプライベートS3バケット
+
 ## deploy
 
 ```sh
-yarn install && \
-cdk deploy
+pnpm install && \
+npx -y aws-cdk@latest deploy
 ```


### PR DESCRIPTION
- CloudFront CDNテンプレートのアーキテクチャ図を追加
- ユーザー、CloudFront、S3、OAC、KMSの関係性を視覚化
- 機能説明セクションを追加してコンポーネントの役割を明記
- AWSサービスの色分けとオプション要素の区別を実装